### PR TITLE
support for multiple model types, logreg model, and regularization

### DIFF
--- a/orca_detector/inference.py
+++ b/orca_detector/inference.py
@@ -16,6 +16,7 @@ import tensorflow as tf
 
 from database_parser import encode_labels, load_features
 from keras.models import Sequential
+from logreg_model import OrcaLogReg
 from orca_params import DatasetType
 from orca_utils import calculate_accuracies
 from vggish_model import OrcaVGGish
@@ -26,21 +27,28 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 RUN_TIMESTAMP = datetime.datetime.now().isoformat('-')
 
 
-def create_network(num_classes, weights_path):
+def create_network(model_name, num_classes, weights_path):
     """ 
     Instantiate trained model from given weights.
     Create the output shape based on num_classes.
     """
 
-    sound_extractor = OrcaVGGish(load_weights=True,
-                                 weights=weights_path,
-                                 out_dim=num_classes,
-                                 pooling='avg').get_model()
-
+    if model_name == 'vggish':
+        sound_extractor = OrcaVGGish(load_weights=True,
+                                     weights=weights_path,
+                                     out_dim=num_classes,
+                                     pooling='avg').get_model()
+    elif model_name == 'logreg':
+        sound_extractor = OrcaLogReg(load_weights=True,
+                                     weights=weights_path,
+                                     out_dim=num_classes).get_model()
+    else:
+        raise Exception('No model specified.  Use `--model_name` arg.')
+        
     return sound_extractor
 
 
-def run(weights_path=None, predict_only=False, **params):
+def run(model_name, weights_path=None, predict_only=False, **params):
 
     print(f'TensorFlow version: {tf.VERSION}')
     print(f'Keras version: {tf.keras.__version__}')
@@ -66,7 +74,7 @@ def run(weights_path=None, predict_only=False, **params):
     if weights_path is None:
         weights_path = os.path.join(orca_params.OUTPUT_PATH,
                                     'orca_weights_latest.hdf5')
-    model = create_network(num_classes, weights_path)
+    model = create_network(model_name, num_classes, weights_path)
 
     results = model.predict(x=test_features,
                             batch_size=orca_params.BATCH_SIZE,
@@ -96,7 +104,16 @@ if __name__ == '__main__':
                         help='Specify the weights path to use.')
     parser.add_argument('--predict_only', action='store_true',
                         help = 'Run inference for unlabeled audio.')
+    parser.add_argument('--model_name',
+                        type=str.lower,
+                        choices=['vggish', 'logreg'],
+                        help='Specify the model name to use.')
     args = parser.parse_args()
+    
+    if not args.model_name:
+        model_name = 'vggish'
+    else:
+        model_name = args.model_name
     
     if not args.predict_only:
         predict_only = False
@@ -104,6 +121,6 @@ if __name__ == '__main__':
         predict_only = True
     
     if args.weights:
-        run(weights=arg.weights, predict_only=predict_only)
+        run(model_name=model_name, weights=arg.weights, predict_only=predict_only)
     else:
-        run(predict_only=predict_only)
+        run(model_name=model_name, predict_only=predict_only)

--- a/orca_detector/inference.py
+++ b/orca_detector/inference.py
@@ -34,18 +34,18 @@ def create_network(model_name, num_classes, weights_path):
     """
 
     if model_name == 'vggish':
-        sound_extractor = OrcaVGGish(load_weights=True,
-                                     weights=weights_path,
-                                     out_dim=num_classes,
-                                     pooling='avg').get_model()
+        model = OrcaVGGish(load_weights=True,
+                           weights=weights_path,
+                           out_dim=num_classes,
+                           pooling='avg').get_model()
     elif model_name == 'logreg':
-        sound_extractor = OrcaLogReg(load_weights=True,
-                                     weights=weights_path,
-                                     out_dim=num_classes).get_model()
+        model = OrcaLogReg(load_weights=True,
+                           weights=weights_path,
+                           out_dim=num_classes).get_model()
     else:
         raise Exception('No model specified.  Use `--model_name` arg.')
         
-    return sound_extractor
+    return model
 
 
 def run(model_name, weights_path=None, predict_only=False, **params):
@@ -106,12 +106,12 @@ if __name__ == '__main__':
                         help = 'Run inference for unlabeled audio.')
     parser.add_argument('--model_name',
                         type=str.lower,
-                        choices=['vggish', 'logreg'],
+                        choices=orca_params.MODEL_NAMES,
                         help='Specify the model name to use.')
     args = parser.parse_args()
     
     if not args.model_name:
-        model_name = 'vggish'
+        model_name = orca_params.DEFAULT_MODEL_NAME
     else:
         model_name = args.model_name
     

--- a/orca_detector/logreg_model.py
+++ b/orca_detector/logreg_model.py
@@ -1,0 +1,109 @@
+# -*- coding: future_fstrings -*-
+
+"""
+Basic LogisticRegression model for audio classification
+
+W251 (Summer 2019) - Spyros Garyfallos, Ram Iyer, Mike Winton
+"""
+
+import numpy as np
+import os
+import sys
+
+from keras.engine.topology import get_source_inputs
+from keras.layers import Flatten, Dense, Input, BatchNormalization
+from keras.models import Model
+# from keras import backend as K
+from keras import optimizers
+
+# project-specific imports
+import mel_params
+import orca_params
+
+
+class OrcaLogReg(object):
+    """
+    An implementation of LogisticRegression
+    """
+
+    def __init__(self,
+                 load_weights=True,
+                 weights=None,
+                 out_dim=None,
+                 optimizer=orca_params.LOGREG_OPTIMIZER,
+                 lr=orca_params.LOGREG_LEARNING_RATE,
+                 loss='categorical_crossentropy',
+                 model_name='OrcaLogReg'):
+        """
+            Args:
+                load_weights = boolean if weights should be loaded
+                weights = weights to load ('audioset' weights are pre-trained on YouTube-8M').
+                out_dim = output dimension
+                pooling = pooling type over the non-top network ('avg' or 'max')
+                optimizer = string name of Keras optimizer
+                loss = string name of Keras loss function
+
+            Returns:
+                A compiled Keras model instance
+        """
+
+        if out_dim is None:
+            out_dim = mel_params.EMBEDDING_SIZE  # 128
+        self.out_dim = out_dim
+
+        self.input_shape = (mel_params.NUM_FRAMES,
+                            mel_params.NUM_BANDS, 1)  # 96, 64, 1
+        print(f'DEBUG: self.input_shape={self.input_shape}')
+        self.audio_input = Input(shape=self.input_shape, name='input_1')
+
+        
+        self.x = BatchNormalization()(self.audio_input)
+        self.x = Flatten(name='orca_flatten_')(self.x)
+        self.x = Dense(self.out_dim, activation='softmax',
+                       name='orca_softmax')(self.x)
+
+        self.inputs = self.audio_input
+        
+        # Instantiate model
+        self.model = Model(inputs=self.inputs, outputs=self.x, name=model_name)
+
+        if load_weights:
+            # Use our own saved weights for running inference
+            print(f'Loading weights from {weights}')
+            if not os.path.exists(weights):
+                raise Exception(f'ERROR: cannot find {weights}.')
+            self.model.load_weights(weights, by_name=True)
+
+        # print representation of the model
+        self.model.summary()
+
+        # instantiate optimizer
+        if optimizer == 'sgd':
+            optimizer_obj = optimizers.SGD(lr=lr)
+        elif optimizer == 'adam':
+            optimizer_obj = optimizers.Adam(lr=lr)
+        else:
+            # Fallback to default params for others
+            optimizer_obj = optimizers.get(optimizer)
+
+        # Build and compile the model
+        self.model.compile(optimizer=optimizer_obj,
+                           loss=loss,
+                           metrics=['accuracy'])
+        print('Compiled {} model with {} optimizer (lr={}) and {} loss.'.format(
+            (model_name), (optimizer), (lr), (loss)))
+
+    def get_model(self):
+        """ Returns a compiled Keras model."""
+        return self.model
+
+
+if __name__ == '__main__':
+
+    """
+    Simple example to confirm if weights can be loaded.
+    """
+    print('Loading OrcaLogReg model:')
+    sound_extractor = OrcaLogReg(load_weights=False).get_model()
+
+    print('Done!')

--- a/orca_detector/orca_params.py
+++ b/orca_detector/orca_params.py
@@ -45,16 +45,20 @@ REMOVE_CLASSES = ['BeardedSeal',  # (NEED TO UNDERSTAND)
                   'TucuxiDolphin'  # 12 training samples
                  ]
 
-# Weighting to account for imbalance when calculating loss
-OPTIMIZER = 'adam'
-LEARNING_RATE = 0.0001  # SGD default LR=0.01; Adam default LR=0.001
 LOSS = 'categorical_crossentropy'
-
-# Model training
-EPOCHS = 30
+EPOCHS = 20
 BATCH_SIZE = 64
 
-# Model hyperparameters
+# Model training - VGGish params
+OPTIMIZER = 'adam'
+LEARNING_RATE = 0.001  # SGD default LR=0.01; Adam default LR=0.001
+DROPOUT = 0.4
+L2_REG_RATE = 0.01  # used for all Dense and Conv2D layers
+
+# Model training - LogReg params
+LOGREG_OPTIMIZER = 'adam'
+LOGREG_LEARNING_RATE = 0.005
+
+# Mel spectrogram hyperparameters
 FILE_MAX_SIZE_SECONDS = 10.00
 FILE_SAMPLING_SIZE_SECONDS = 0.98
-DROPOUT = 0.4

--- a/orca_detector/orca_params.py
+++ b/orca_detector/orca_params.py
@@ -48,11 +48,14 @@ REMOVE_CLASSES = ['BeardedSeal',  # (NEED TO UNDERSTAND)
 LOSS = 'categorical_crossentropy'
 EPOCHS = 20
 BATCH_SIZE = 64
+MODEL_NAMES = ['vggish', 'logreg']
+DEFAULT_MODEL_NAME = 'vggish'
 
 # Model training - VGGish params
 OPTIMIZER = 'adam'
 LEARNING_RATE = 0.001  # SGD default LR=0.01; Adam default LR=0.001
 DROPOUT = 0.4
+FINAL_DENSE_NODES = 256
 L2_REG_RATE = 0.01  # used for all Dense and Conv2D layers
 
 # Model training - LogReg params

--- a/orca_detector/train.py
+++ b/orca_detector/train.py
@@ -32,17 +32,17 @@ def create_network(model_name, classes):
     """
 
     if model_name == 'vggish':
-        sound_extractor = OrcaVGGish(load_weights=True,
-                                     weights='audioset',
-                                     out_dim=len(classes),
-                                     pooling='avg').get_model()
+        model = OrcaVGGish(load_weights=True,
+                           weights='audioset',
+                           out_dim=len(classes),
+                           pooling='avg').get_model()
     elif model_name == 'logreg':
-        sound_extractor = OrcaLogReg(load_weights=False,
-                                     out_dim=len(classes)).get_model()
+        model = OrcaLogReg(load_weights=False,
+                           out_dim=len(classes)).get_model()
     else:
         raise Exception('No model specified.  Use `--model_name` arg.')
         
-    return sound_extractor
+    return model
 
 
 def run(model_name, **params):
@@ -94,12 +94,12 @@ if __name__ == '__main__':
                         epilog='by Spyros Garyfallos, Ram Iyer, Mike Winton')
     parser.add_argument('--model_name',
                         type=str.lower,
-                        choices=['vggish', 'logreg'],
+                        choices=orca_params.MODEL_NAMES,
                         help='Specify the model name to use.')
     args = parser.parse_args()
     
     if not args.model_name:
-        model_name = 'vggish'
+        model_name = orca_params.DEFAULT_MODEL_NAME
     else:
         model_name = args.model_name
 

--- a/orca_detector/train.py
+++ b/orca_detector/train.py
@@ -6,15 +6,18 @@ Main file to train a model for the Orca project.
 W251 (Summer 2019) - Spyros Garyfallos, Ram Iyer, Mike Winton
 """
 
-from vggish_model import OrcaVGGish
-from orca_utils import plot_train_metrics, save_model
-from orca_params import DatasetType
-from database_parser import load_features, create_label_encoding, encode_labels
+import argparse
+import datetime
 import orca_params
 import os
 import tensorflow as tf
-import datetime
+
+from database_parser import load_features, create_label_encoding, encode_labels
 from keras.models import Sequential
+from logreg_model import OrcaLogReg
+from orca_params import DatasetType
+from orca_utils import plot_train_metrics, save_model
+from vggish_model import OrcaVGGish
 
 # Reduce TensorFlow verbosity
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
@@ -22,21 +25,27 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 RUN_TIMESTAMP = datetime.datetime.now().isoformat('-')
 
 
-def create_network(classes):
+def create_network(model_name, classes):
     """ 
     Instantiate but don't yet fit the model.
     Create the output shape based on the classes length
     """
 
-    sound_extractor = OrcaVGGish(load_weights=True,
-                                 weights='audioset',
-                                 out_dim=len(classes),
-                                 pooling='avg').get_model()
-
+    if model_name == 'vggish':
+        sound_extractor = OrcaVGGish(load_weights=True,
+                                     weights='audioset',
+                                     out_dim=len(classes),
+                                     pooling='avg').get_model()
+    elif model_name == 'logreg':
+        sound_extractor = OrcaLogReg(load_weights=False,
+                                     out_dim=len(classes)).get_model()
+    else:
+        raise Exception('No model specified.  Use `--model_name` arg.')
+        
     return sound_extractor
 
 
-def run(**params):
+def run(model_name, **params):
 
     print(f'TensorFlow version: {tf.VERSION}')
     print(f'Keras version: {tf.keras.__version__}')
@@ -59,7 +68,7 @@ def run(**params):
           f'{orca_params.OTHER_CLASSES}\n')
     
 
-    model = create_network(classes)
+    model = create_network(model_name, classes)
 
     history = model.fit(x=train_features,
                         y=train_labels,
@@ -80,4 +89,18 @@ def run(**params):
 
 
 if __name__ == '__main__':
-    run()
+    # parse command line parameters and flags
+    parser = argparse.ArgumentParser(description='OrcaDetector - W251 (Summer 2019)',
+                        epilog='by Spyros Garyfallos, Ram Iyer, Mike Winton')
+    parser.add_argument('--model_name',
+                        type=str.lower,
+                        choices=['vggish', 'logreg'],
+                        help='Specify the model name to use.')
+    args = parser.parse_args()
+    
+    if not args.model_name:
+        model_name = 'vggish'
+    else:
+        model_name = args.model_name
+
+    run(model_name)

--- a/orca_detector/vggish_model.py
+++ b/orca_detector/vggish_model.py
@@ -17,6 +17,7 @@ from keras.layers import Flatten, Dense, Input, Conv2D, MaxPooling2D, \
     GlobalAveragePooling2D, GlobalMaxPooling2D, BatchNormalization, \
     Dropout
 from keras.engine.topology import get_source_inputs
+from keras.regularizers import l2
 from keras import backend as K
 from keras import optimizers
 
@@ -46,29 +47,35 @@ class VGGish(object):
         """
 
         # Block 1
-        self.x = Conv2D(64, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(64, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv1')(self.x)
         self.x = MaxPooling2D((2, 2), strides=(2, 2), padding='same',
                               name='pool1')(self.x)
 
         # Block 2
-        self.x = Conv2D(128, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(128, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv2')(self.x)
         self.x = MaxPooling2D((2, 2), strides=(2, 2),
                               padding='same', name='pool2')(self.x)
 
         # Block 3
-        self.x = Conv2D(256, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(256, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv3/conv3_1')(self.x)
-        self.x = Conv2D(256, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(256, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv3/conv3_2')(self.x)
-        self.x = MaxPooling2D((2, 2), strides=(2, 2), padding='same',
-                              name='pool3')(self.x)
+        self.x = MaxPooling2D((2, 2), strides=(2, 2),
+                              padding='same', name='pool3')(self.x)
 
         # Block 4
-        self.x = Conv2D(512, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(512, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv4/conv4_1')(self.x)
-        self.x = Conv2D(512, (3, 3), strides=(1, 1), activation='relu',
+        self.x = Conv2D(512, (3, 3), kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                        strides=(1, 1), activation='relu',
                         padding='same', name='conv4/conv4_2')(self.x)
 
     def _build_vggish_top_layers(self):
@@ -236,15 +243,15 @@ class OrcaVGGish(VGGish):
         """
 
         # Dropout to prevent overfitting
-        self.x = Dropout(self.dropout)(self.x)
+        self.x = Dropout(self.dropout, name='orca_dropout')(self.x)
 
         # FC block
         self.x = MaxPooling2D((2, 2), strides=(2, 2), padding='same',
                               name='orca_pool4')(self.x)
-        self.x = Flatten(name='orca_flatten_')(self.x)
-        self.x = Dense(4096, activation='relu',
+        self.x = Flatten(name='orca_flatten')(self.x)
+        self.x = Dense(256, kernel_regularizer=l2(orca_params.L2_REG_RATE), activation='relu',
                        name='orca_fc1/orca_fc1_1')(self.x)
-        self.x = Dense(4096, activation='relu',
+        self.x = Dense(256, kernel_regularizer=l2(orca_params.L2_REG_RATE), activation='relu',
                        name='orca_fc1/orca_fc1_2')(self.x)
         self.x = Dense(self.out_dim, activation='softmax',
                        name='orca_softmax')(self.x)

--- a/orca_detector/vggish_model.py
+++ b/orca_detector/vggish_model.py
@@ -249,9 +249,13 @@ class OrcaVGGish(VGGish):
         self.x = MaxPooling2D((2, 2), strides=(2, 2), padding='same',
                               name='orca_pool4')(self.x)
         self.x = Flatten(name='orca_flatten')(self.x)
-        self.x = Dense(256, kernel_regularizer=l2(orca_params.L2_REG_RATE), activation='relu',
+        self.x = Dense(orca_params.FINAL_DENSE_NODES,
+                       kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                       activation='relu',
                        name='orca_fc1/orca_fc1_1')(self.x)
-        self.x = Dense(256, kernel_regularizer=l2(orca_params.L2_REG_RATE), activation='relu',
+        self.x = Dense(orca_params.FINAL_DENSE_NODES,
+                       kernel_regularizer=l2(orca_params.L2_REG_RATE),
+                       activation='relu',
                        name='orca_fc1/orca_fc1_2')(self.x)
         self.x = Dense(self.out_dim, activation='softmax',
                        name='orca_softmax')(self.x)


### PR DESCRIPTION
- created an `OrcaLogReg` logistic regression model so we can report a baseline to compare our neural model against
- updated `train.py` and `inference.py` to both accept `--model_name` arg to specify `vggish` or `logreg`
- added support for regularization in the VGGish model
- some updates and minor reorganization of hyperparams in `orca_params.py`