### PR TITLE
catching ValueError. Creating subdirs for multiple detections

### DIFF
--- a/orca_detector/live_feed_listener.py
+++ b/orca_detector/live_feed_listener.py
@@ -20,6 +20,7 @@ import sys
 import time
 import uuid
 import urllib.request
+import uuid
 from threading import Thread
 from database_parser import extract_segment_features
 from inference import create_network
@@ -60,7 +61,7 @@ def _save_audio_segments(stream_url,
                  f'-f segment -segment_time {segment_seconds} {output_file}'
     
     # TODO: delete this print statement later
-    print(f'DEBUG - ffmpeg mixing command: {ffmpeg_cli}')
+    # print(f'DEBUG - ffmpeg mixing command: {ffmpeg_cli}')
 
     if not verbose:
         ffmpeg_cli = ffmpeg_cli + ' -loglevel error'
@@ -116,8 +117,10 @@ def _perform_inference(model, encoder, inference_samples_path, probability_thres
                                    & (results[:, [1]] != orca_params.NOISE_CLASS).ravel()]
 
         if len(results) > 0:
+            # Create a randomly named subdirectory to avoid overwriting prior finds
+            subdir = uuid.uuid4().hex
             destination_folder = os.path.join(
-                orca_params.DETECTIONS_PATH, POSITIVE_INFERENCE_TIMESTAMP)
+                orca_params.DETECTIONS_PATH, POSITIVE_INFERENCE_TIMESTAMP, subdir)
             shutil.copytree(inference_samples_path, destination_folder)
             print(f'Copied positive inference results at:{destination_folder}')
             pd.DataFrame(results).to_csv(os.path.join(destination_folder, "results.csv"))
@@ -130,6 +133,8 @@ def _perform_inference(model, encoder, inference_samples_path, probability_thres
         print('Thread collision; multiple threads processing same audio files.')
         print('Unable to perform inference for {}'.format(
             (inference_samples_path)))
+    except ValueError:
+        print('Could not process input sample.  Possibly zero length.')
 
     return results
 

--- a/orca_detector/vggish_model.py
+++ b/orca_detector/vggish_model.py
@@ -197,7 +197,7 @@ class VGGish(object):
             else:
                 print(f'Loading weights from {weights}')
                 if not os.path.exists(weights):
-                    raise Exception('ERROR: cannot find {weights}.')
+                    raise Exception(f'ERROR: cannot find {weights}.')
                 self.model.load_weights(weights, by_name=True)
                 
 


### PR DESCRIPTION
Fixed an issue where code would crash if an empty sample was processed.  (Gracefully catch the error and continue.)

Also fixed an issue where multiple detections made during a (long) live feed inference run could overwrite each other.  Creating subdirectories under the `/detections/<timestamp>` to hold samples.